### PR TITLE
fix: limit concurrent goroutine

### DIFF
--- a/examples/keys_cap.go
+++ b/examples/keys_cap.go
@@ -42,8 +42,8 @@ func main() {
 		context.Background(),
 		batchFetchNumbers,
 		dataloader2.WithBatchDuration[int, string](16*time.Millisecond),
-		dataloader2.WithBatchCap[int, string](1_000),
-		//dataloader2.WithWorker[int, string](2),
+		dataloader2.WithBatchCap[int, string](100),
+		dataloader2.WithWorker[int, string](10),
 	)
 	defer flush()
 

--- a/examples/load_many.go
+++ b/examples/load_many.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"time"
+
+	"github.com/alextanhongpin/dataloader2"
+)
+
+func batchFetchNumbers(ctx context.Context, keys []int) (map[int]string, error) {
+	fmt.Println("fetching keys", len(keys), keys)
+	time.Sleep(1 * time.Second)
+
+	result := make(map[int]string, len(keys))
+	for _, k := range keys {
+		result[k] = fmt.Sprint(k)
+	}
+
+	return result, nil
+}
+
+func main() {
+	start := time.Now()
+	defer func() {
+		fmt.Println(time.Since(start))
+	}()
+
+	fmt.Println("worker", runtime.NumCPU())
+
+	dl2, flush := dataloader2.New(
+		context.Background(),
+		batchFetchNumbers,
+		dataloader2.WithBatchCap[int, string](50),
+	)
+	defer flush()
+
+	n := 1_00
+
+	numbers := make([]int, n)
+	for i := 0; i < n; i++ {
+		numbers[i] = i
+	}
+	result, err := dl2.LoadMany(numbers)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, res := range result {
+		fmt.Println(res.Unwrap())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/alextanhongpin/dataloader2
 
 go 1.18
+
+require golang.org/x/sync v0.0.0-20220513210516-0976fa681c29

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 h1:w8s32wxx3sY+OjLlv9qltkLU5yvJzxjjgiHWLjdIcw4=
+golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/option.go
+++ b/option.go
@@ -1,12 +1,16 @@
 package dataloader2
 
-import "time"
+import (
+	"time"
+
+	"golang.org/x/sync/semaphore"
+)
 
 type Option[K comparable, T any] func(*Dataloader[K, T])
 
 func WithWorker[K comparable, T any](n int) Option[K, T] {
 	return func(d *Dataloader[K, T]) {
-		d.worker = n
+		d.worker = semaphore.NewWeighted(int64(n))
 	}
 }
 


### PR DESCRIPTION
resolves #2 

- use semaphore to limit concurrent goroutine running `batchFunc`
- ensure context in `batchFunc` is cancelled when `done` channel is closed
- `Load` is separated into two parts, with `loadThunk` method sending the key to the `ch` and returning the thunk only. This allows `LoadMany` to block when the channel `batchCap` is specified.
- use `wg.Add(1)` instead of `wg.Add(len(keys))`, which could potentially create millions of goroutines when millions of keys are specified