### PR TITLE
fix: remove semaphore dependency, fix data race issue with mutex

### DIFF
--- a/examples/error.go
+++ b/examples/error.go
@@ -39,4 +39,28 @@ func main() {
 	for _, res := range result {
 		fmt.Println(res.Unwrap())
 	}
+
+	go func() {
+
+		res, err := dl2.Load(1)
+		if err != nil {
+			fmt.Println(err)
+		}
+		fmt.Println(res)
+	}()
+	go func() {
+		fmt.Println("primed", dl2.Prime(1, "hello world"))
+
+		res, err := dl2.Load(1)
+		if err != nil {
+			fmt.Println("error", err)
+		}
+		fmt.Println("primed result", res)
+	}()
+
+	select {
+	case <-time.After(2 * time.Second):
+		fmt.Println("exiting")
+		return
+	}
 }

--- a/examples/keys_cap.go
+++ b/examples/keys_cap.go
@@ -58,7 +58,7 @@ func main() {
 			fmt.Println("start worker", i)
 			randSleep()
 
-			res, err := dl2.Load(i)
+			res, err := dl2.Load(i / 2)
 			if err != nil {
 				panic(err)
 			}

--- a/examples/missing_keys.go
+++ b/examples/missing_keys.go
@@ -34,6 +34,7 @@ func main() {
 	defer flush()
 
 	n := 10
+
 	var wg sync.WaitGroup
 	wg.Add(n)
 
@@ -42,7 +43,7 @@ func main() {
 		go func(i int) {
 			defer wg.Done()
 
-			fmt.Println("start worker", i)
+			fmt.Println("start worker", i, i/2)
 			res, err := dl2.Load(i / 2)
 			if err != nil {
 				fmt.Println("worker error", i, err)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/alextanhongpin/dataloader2
 
 go 1.18
-
-require golang.org/x/sync v0.0.0-20220513210516-0976fa681c29

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 h1:w8s32wxx3sY+OjLlv9qltkLU5yvJzxjjgiHWLjdIcw4=
-golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/option.go
+++ b/option.go
@@ -2,15 +2,13 @@ package dataloader2
 
 import (
 	"time"
-
-	"golang.org/x/sync/semaphore"
 )
 
 type Option[K comparable, T any] func(*Dataloader[K, T])
 
 func WithWorker[K comparable, T any](n int) Option[K, T] {
 	return func(d *Dataloader[K, T]) {
-		d.worker = semaphore.NewWeighted(int64(n))
+		d.worker = make(chan struct{}, n)
 	}
 }
 


### PR DESCRIPTION
- no need to depend on external semaphore package when you can use channels
- data race issue with reading mutex - state may still change before setting, increase critical area